### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,44 @@
 # Text2SQL Agent
 
-This project is focused on developing a high-performance Text2SQL agent designed for large-scale and multi-database systems. It uses advanced techniques such as:
+## Overview
+This project implements a high-performance agent that translates natural language questions into SQL. The goal is to support large-scale deployments across multiple databases.
 
-- Retrieval-Augmented Generation (RAG)
-- ReAct agent architecture
-- Multi-agent coordination
+The core logic combines:
+- **Retrieval-Augmented Generation (RAG)** for using schema and example queries.
+- **ReAct-style agent planning** to iteratively build and verify SQL.
+- **Multi-agent coordination** for complex or multi-step requests.
 
-## Based on Vanna
+## Implementation
+The agent is built on top of the [Vanna project](https://github.com/vanna-ai/vanna). The `main.py` file shows a reference setup:
 
-This project builds on top of core utilities from the [Vanna project](https://github.com/vanna-ai/vanna), which provides foundational components for natural language to SQL interfaces.
+1. `MyVanna` extends `ChromaDB_VectorStore` and `OpenAI_Chat` to provide both vector search and LLM chat capabilities.
+2. The agent connects to an AvalAI (OpenAI-compatible) endpoint and a Microsoft SQL Server instance (`AdventureWorks2022`).
+3. Optional training uses the database schema to create a plan and feed context to the model.
+4. Users may interact from the command line or launch a small Flask application for a web interface.
+
+The agent ultimately exposes `ask_agent()` for natural language questions which returns generated SQL results.
+
+## Dataset
+Example prompts and queries live under `datasets/`. They are organized by SQL concept to help evaluate model performance. Categories include:
+- **Basic Queries**
+- **Joins**
+- **Aggregation**
+- **Sorting and Limiting**
+- **String/Text Handling**
+- **Filtering**
+- **Subqueries**
+- **Window Functions**
+- **Set Operations**
+
+See [`datasets/readme.md`](datasets/readme.md) for full details on each directory.
+
+## Getting Started
+Install requirements and then run the main script:
+```bash
+pip install -r requirements.txt
+python main.py
+```
+You will be prompted for optional training steps and whether to open the web interface.
+
+## License
+This project reuses utilities from Vanna which are licensed under the MIT License. Please see the `vanna` directory for more information.


### PR DESCRIPTION
## Summary
- expand README with detailed implementation and dataset overview
- remove leftover shell prompt from end of file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vanna')*

------
https://chatgpt.com/codex/tasks/task_e_686cceb94dc88320a6f5c10fe378542e