### PR TITLE
Add CLI and caching to dataset tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Example prompts and queries live under `datasets/`. They are organized by SQL co
 
 See [`datasets/readme.md`](datasets/readme.md) for full details on each directory.
 
+### Automated dataset testing
+The `datasets/test_dataset_aw.py` script can run all prompt/query pairs against a
+Vanna model and generate CSV reports. It now supports command line arguments to
+configure the dataset location, connection string, model name, method
+(`ask` or `ask_agent`), and test level (number of prompt variants). Ground truth
+query results are cached to avoid re-running SQL on subsequent executions. After
+all tests finish an aggregate summary CSV is written with per-category accuracy
+and overall success rate.
+
 ## Getting Started
 Install requirements and then run the main script:
 ```bash


### PR DESCRIPTION
## Summary
- add argparse CLI for dataset test harness
- cache ground truth results
- support optional `ask_agent` method
- compute aggregate accuracy metrics
- document dataset testing in README

## Testing
- `python -m py_compile datasets/test_dataset_aw.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d0aedad8083208e881931646c2ad2