### PR TITLE
Add follow-up prompts for AdventureWorks

### DIFF
--- a/datasets/dataset_AdventureWorks2022/aggr/prompt00.json
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt00.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Calculate yearly order statistics: count of orders, total subtotal amount, and average tax amount, grouped and ordered by the year of OrderDate.",
+  "poorly-explained": "Show annual orders and tax.",
+  "underspecified": "Give me order stats per year.",
+  "follow-up": "Include the tax collected for each year."
+}

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt00.txt
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt00.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Calculate yearly order statistics: count of orders, total subtotal amount, and average tax amount, grouped and ordered by the year of OrderDate."
-
-Poorly-Explained Prompt
-"Show annual orders and tax."
-
-Underspecified Prompt
-"Give me order stats per year."

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt01.json
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt01.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List customers who have spent more than $5,000 total, showing their ID, count of orders, and total amount spent, sorted by spending descending.",
+  "poorly-explained": "Find big spenders.",
+  "underspecified": "Show customer spending.",
+  "follow-up": "Focus on customers who spent more than usual."
+}

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt01.txt
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt01.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List customers who have spent more than $5,000 total, showing their ID, count of orders, and total amount spent, sorted by spending descending."
-
-Poorly-Explained Prompt
-"Find big spenders."
-
-Underspecified Prompt
-"Show customer spending."

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt02.json
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt02.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "For each product category, count distinct products, compute average and maximum list price, and order categories by average price descending.",
+  "poorly-explained": "Show category stats for products.",
+  "underspecified": "List categories with product prices.",
+  "follow-up": "Provide counts and average/max prices per category."
+}

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt02.txt
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt02.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"For each product category, count distinct products, compute average and maximum list price, and order categories by average price descending."
-
-Poorly-Explained Prompt
-"Show category stats for products."
-
-Underspecified Prompt
-"List categories with product prices."

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt03.json
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt03.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Aggregate sales by territory: number of distinct customers, total freight, and average freight, ordered by total freight descending.",
+  "poorly-explained": "Territory shipping costs.",
+  "underspecified": "Show freight per territory.",
+  "follow-up": "Show total and average freight per territory."
+}

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt03.txt
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt03.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Aggregate sales by territory: number of distinct customers, total freight, and average freight, ordered by total freight descending."
-
-Poorly-Explained Prompt
-"Territory shipping costs."
-
-Underspecified Prompt
-"Show freight per territory."

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt04.json
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt04.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Identify vendors supplying at least 3 products; show vendor ID, number of products, total and average lead time, ordered by average lead time.",
+  "poorly-explained": "Vendors with many products.",
+  "underspecified": "List vendors and lead times.",
+  "follow-up": "Only include vendors with at least three products."
+}

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt04.txt
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt04.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Identify vendors supplying at least 3 products; show vendor ID, number of products, total and average lead time, ordered by average lead time."
-
-Poorly-Explained Prompt
-"Vendors with many products."
-
-Underspecified Prompt
-"List vendors and lead times."

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt05.json
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt05.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Compute the number of shipped orders, total revenue, and average freight per order for each year, using only orders with Status = 5.",
+  "poorly-explained": "Show yearly shipped order numbers with revenue and freight average.",
+  "underspecified": "Give yearly order stats.",
+  "follow-up": "Look only at shipped orders and report revenue and average freight."
+}

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt05.txt
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt05.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Compute the number of shipped orders, total revenue, and average freight per order for each year, using only orders with Status = 5."
-
-Poorly-Explained Prompt
-"Show yearly shipped order numbers with revenue and freight average."
-
-Underspecified Prompt
-"Give yearly order stats."

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt06.json
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt06.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Identify customers with more than 10 orders; for each, show their ID, number of orders, sum of subtotals, and highest total‑due order, sorted by subtotal descending.",
+  "poorly-explained": "Show customers who order a lot and their spending.",
+  "underspecified": "Show customer order aggregates.",
+  "follow-up": "Return customers with over ten orders and highlight the largest order."
+}

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt06.txt
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt06.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Identify customers with more than 10 orders; for each, show their ID, number of orders, sum of subtotals, and highest total‑due order, sorted by subtotal descending."
-
-Poorly-Explained Prompt
-"Show customers who order a lot and their spending."
-
-Underspecified Prompt
-"Show customer order aggregates."

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt07.json
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt07.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List customers whose total spending exceeds the overall average order total, showing their ID, number of orders, and total spent, ordered by spending descending.",
+  "poorly-explained": "Big spenders above average.",
+  "underspecified": "Show top customers spending.",
+  "follow-up": "Limit results to customers spending above the overall average."
+}

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt07.txt
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt07.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List customers whose total spending exceeds the overall average order total, showing their ID, number of orders, and total spent, ordered by spending descending."
-
-Poorly-Explained Prompt
-"Big spenders above average."
-
-Underspecified Prompt
-"Show top customers spending."

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt08.json
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt08.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find the vendor(s) who supply the maximum number of distinct products; output their vendor ID, number of products, and average lead time, ordered by lead time ascending.",
+  "poorly-explained": "Top vendor by product count.",
+  "underspecified": "Show vendor stats.",
+  "follow-up": "Identify the vendor supplying the most distinct products."
+}

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt08.txt
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt08.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find the vendor(s) who supply the maximum number of distinct products; output their vendor ID, number of products, and average lead time, ordered by lead time ascending."
-
-Poorly-Explained Prompt
-"Top vendor by product count."
-
-Underspecified Prompt
-"Show vendor stats."

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt09.json
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt09.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Identify customers whose average order value exceeds the average order value for all orders placed in 2011; show their ID, number of orders, total spent, and average order value, sorted by total spent descending.",
+  "poorly-explained": "Show customers with higher average orders than year 2011.",
+  "underspecified": "Customer average order values.",
+  "follow-up": "Compare their average order value to the 2011 average."
+}

--- a/datasets/dataset_AdventureWorks2022/aggr/prompt09.txt
+++ b/datasets/dataset_AdventureWorks2022/aggr/prompt09.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Identify customers whose average order value exceeds the average order value for all orders placed in 2011; show their ID, number of orders, total spent, and average order value, sorted by total spent descending."
-
-Poorly-Explained Prompt
-"Show customers with higher average orders than year 2011."
-
-Underspecified Prompt
-"Customer average order values."

--- a/datasets/dataset_AdventureWorks2022/filter/prompt00.json
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt00.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Return the ID and name of products that have never been ordered.",
+  "poorly-explained": "Products that never sold.",
+  "underspecified": "Give me product list.",
+  "follow-up": "Only include products that have never been ordered."
+}

--- a/datasets/dataset_AdventureWorks2022/filter/prompt00.txt
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt00.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Return the ID and name of products that have never been ordered."
-
-Poorly-Explained Prompt
-"Products that never sold."
-
-Underspecified Prompt
-"Give me product list."

--- a/datasets/dataset_AdventureWorks2022/filter/prompt01.json
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt01.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find customers who have placed orders after January 1, 2011, and return their ID and store name.",
+  "poorly-explained": "Get customers with recent orders.",
+  "underspecified": "Show customer information.",
+  "follow-up": "Filter for customers with orders after 2011-01-01."
+}

--- a/datasets/dataset_AdventureWorks2022/filter/prompt01.txt
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt01.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find customers who have placed orders after January 1, 2011, and return their ID and store name."
-
-Poorly-Explained Prompt
-"Get customers with recent orders."
-
-Underspecified Prompt
-"Show customer information."

--- a/datasets/dataset_AdventureWorks2022/filter/prompt02.json
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt02.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List employees whose pay rate is not above 100, showing their business entity ID, first name, and last name.",
+  "poorly-explained": "Give me employees without high pay rates.",
+  "underspecified": "Show employee details.",
+  "follow-up": "Exclude anyone earning more than 100."
+}

--- a/datasets/dataset_AdventureWorks2022/filter/prompt02.txt
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt02.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List employees whose pay rate is not above 100, showing their business entity ID, first name, and last name."
-
-Poorly-Explained Prompt
-"Give me employees without high pay rates."
-
-Underspecified Prompt
-"Show employee details."

--- a/datasets/dataset_AdventureWorks2022/filter/prompt03.json
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt03.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List vendors who have never had a purchase order with a total amount greater than 1000, showing their ID and name.",
+  "poorly-explained": "Get vendors who didn’t make big sales.",
+  "underspecified": "Show vendor list.",
+  "follow-up": "Select vendors without any purchase over 1000."
+}

--- a/datasets/dataset_AdventureWorks2022/filter/prompt03.txt
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt03.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List vendors who have never had a purchase order with a total amount greater than 1000, showing their ID and name."
-
-Poorly-Explained Prompt
-"Get vendors who didn’t make big sales."
-
-Underspecified Prompt
-"Show vendor list."

--- a/datasets/dataset_AdventureWorks2022/filter/prompt04.json
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt04.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find products that have no inventory recorded (i.e., where the inventory quantity is NULL). Return the product ID and name.",
+  "poorly-explained": "Show products with no inventory.",
+  "underspecified": "List products.",
+  "follow-up": "Look for items with NULL quantity."
+}

--- a/datasets/dataset_AdventureWorks2022/filter/prompt04.txt
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt04.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find products that have no inventory recorded (i.e., where the inventory quantity is NULL). Return the product ID and name."
-
-Poorly-Explained Prompt
-"Show products with no inventory."
-
-Underspecified Prompt
-"List products."

--- a/datasets/dataset_AdventureWorks2022/filter/prompt05.json
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt05.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find products that is out of stock. Return the product ID and name.",
+  "poorly-explained": "Show products that are out of stock.",
+  "underspecified": "List products.",
+  "follow-up": "Find products whose inventory quantity equals zero."
+}

--- a/datasets/dataset_AdventureWorks2022/filter/prompt05.txt
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt05.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find products that is out of stock. Return the product ID and name."
-
-Poorly-Explained Prompt
-"Show products with no inventory."
-
-Underspecified Prompt
-"List products."

--- a/datasets/dataset_AdventureWorks2022/filter/prompt06.json
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt06.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find salespeople who have processed orders where the total due is greater than 1000. Show their business entity ID, first name, and last name.",
+  "poorly-explained": "Get salespeople with high-value orders.",
+  "underspecified": "List salespeople.",
+  "follow-up": "Keep salespeople involved in orders over 1000."
+}

--- a/datasets/dataset_AdventureWorks2022/filter/prompt06.txt
+++ b/datasets/dataset_AdventureWorks2022/filter/prompt06.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find salespeople who have processed orders where the total due is greater than 1000. Show their business entity ID, first name, and last name."
-
-Poorly-Explained Prompt
-"Get salespeople with high-value orders."
-
-Underspecified Prompt
-"List salespeople."

--- a/datasets/dataset_AdventureWorks2022/join/prompt00.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt00.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Retrieve the product name, order date, and total due for sales orders where the total due exceeds $10,000. Include only products that were part of those orders and sort by order date in descending order.",
+  "poorly-explained": "Get products and order stuff where total is big and sort by newest.",
+  "underspecified": "Show me some product sales.",
+  "follow-up": "Restrict to orders over 10000 and sort newest first."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt00.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt00.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Retrieve the product name, order date, and total due for sales orders where the total due exceeds $10,000. Include only products that were part of those orders and sort by order date in descending order."
-
-Poorly-Explained Prompt
-"Get products and order stuff where total is big and sort by newest."
-
-Underspecified Prompt
-"Show me some product sales."

--- a/datasets/dataset_AdventureWorks2022/join/prompt01.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt01.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List the first and last names, job titles, and hire dates of employees who were hired before January 1st, 2015, and whose job title contains the word 'Manager'.",
+  "poorly-explained": "Show me who were managers before 2015.",
+  "underspecified": "Give me employee names and job titles.",
+  "follow-up": "Include managers hired before 2015."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt01.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt01.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List the first and last names, job titles, and hire dates of employees who were hired before January 1st, 2015, and whose job title contains the word 'Manager'."
-
-Poorly-Explained Prompt
-"Show me who were managers before 2015."
-
-Underspecified Prompt
-"Give me employee names and job titles."

--- a/datasets/dataset_AdventureWorks2022/join/prompt02.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt02.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find the vendor names, product names, and credit ratings for vendors with a credit rating of 3 or lower. Sort the result by credit rating in ascending order.",
+  "poorly-explained": "Which vendors have bad ratings and what do they sell?",
+  "underspecified": "List vendor products.",
+  "follow-up": "Filter vendors with credit rating 3 or less."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt02.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt02.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find the vendor names, product names, and credit ratings for vendors with a credit rating of 3 or lower. Sort the result by credit rating in ascending order."
-
-Poorly-Explained Prompt
-"Which vendors have bad ratings and what do they sell?"
-
-Underspecified Prompt
-"List vendor products."

--- a/datasets/dataset_AdventureWorks2022/join/prompt03.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt03.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Show the first and last names of people along with their street address, city, state/province name, and country name.",
+  "poorly-explained": "Give me names and addresses of people.",
+  "underspecified": "List people and where they live.",
+  "follow-up": "Show street, city, state and country for each person."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt03.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt03.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Show the first and last names of people along with their street address, city, state/province name, and country name."
-
-Poorly-Explained Prompt
-"Give me names and addresses of people."
-
-Underspecified Prompt
-"List people and where they live."

--- a/datasets/dataset_AdventureWorks2022/join/prompt04.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt04.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find each customer's ID and full name along with the total amount they've spent across all orders, using the Customer, Person, and SalesOrderHeader tables.",
+  "poorly-explained": "Show customer spending.",
+  "underspecified": "List customers and how much they spent.",
+  "follow-up": "Sum up spending for every customer."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt04.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt04.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find each customer's ID and full name along with the total amount they've spent across all orders, using the Customer, Person, and SalesOrderHeader tables."
-
-Poorly-Explained Prompt
-"Show customer spending."
-
-Underspecified Prompt
-"List customers and how much they spent."

--- a/datasets/dataset_AdventureWorks2022/join/prompt05.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt05.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List the product name, quantity, location ID, and location name for inventory records where the quantity is between 100 and 300 units. Sort the results by quantity in descending order.",
+  "poorly-explained": "Which items have a medium amount in stock?",
+  "underspecified": "Give me product inventory info.",
+  "follow-up": "Return inventory rows with quantity between 100 and 300."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt05.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt05.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List the product name, quantity, location ID, and location name for inventory records where the quantity is between 100 and 300 units. Sort the results by quantity in descending order."
-
-Poorly-Explained Prompt
-"Which items have a medium amount in stock?"
-
-Underspecified Prompt
-"Give me product inventory info."

--- a/datasets/dataset_AdventureWorks2022/join/prompt06.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt06.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Count how many products belong to each product category, joining Product → ProductSubcategory → ProductCategory.",
+  "poorly-explained": "Give me product counts by category.",
+  "underspecified": "How many products are in categories?",
+  "follow-up": "Count products within each category."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt06.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt06.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Count how many products belong to each product category, joining Product → ProductSubcategory → ProductCategory."
-
-Poorly-Explained Prompt
-"Give me product counts by category."
-
-Underspecified Prompt
-"How many products are in categories?"

--- a/datasets/dataset_AdventureWorks2022/join/prompt07.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt07.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List current employees (those without an EndDate) with their IDs, names, and department, using EmployeeDepartmentHistory, Department, Employee, and Person.",
+  "poorly-explained": "Who works where now?",
+  "underspecified": "Show employee departments.",
+  "follow-up": "List current employees and their departments."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt07.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt07.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List current employees (those without an EndDate) with their IDs, names, and department, using EmployeeDepartmentHistory, Department, Employee, and Person."
-
-Poorly-Explained Prompt
-"Who works where now?"
-
-Underspecified Prompt
-"Show employee departments."

--- a/datasets/dataset_AdventureWorks2022/join/prompt08.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt08.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List employee IDs, names, departments, shift names, and hire dates for all employees.",
+  "poorly-explained": "Tell me about employees and where they work.",
+  "underspecified": "Give me employee info.",
+  "follow-up": "Show department and shift for all employees."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt08.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt08.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List employee IDs, names, departments, shift names, and hire dates for all employees."
-
-Poorly-Explained Prompt
-"Tell me about employees and where they work."
-
-Underspecified Prompt
-"Give me employee info."

--- a/datasets/dataset_AdventureWorks2022/join/prompt09.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt09.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Retrieve each order’s ID and date along with each product sold in that order and its quantity, joining SalesOrderHeader → SalesOrderDetail → Product.",
+  "poorly-explained": "Show orders and products.",
+  "underspecified": "List order items.",
+  "follow-up": "Give each order with its products and quantities."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt09.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt09.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Retrieve each order’s ID and date along with each product sold in that order and its quantity, joining SalesOrderHeader → SalesOrderDetail → Product."
-
-Poorly-Explained Prompt
-"Show orders and products."
-
-Underspecified Prompt
-"List order items."

--- a/datasets/dataset_AdventureWorks2022/join/prompt10.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt10.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find vendors supplying more than five distinct products; show vendor name, count of products, and sum of list‑price times vendor standard price.",
+  "poorly-explained": "Which vendors have lots of products?",
+  "underspecified": "List vendors and products.",
+  "follow-up": "Only vendors with more than five products."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt10.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt10.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find vendors supplying more than five distinct products; show vendor name, count of products, and sum of list‑price times vendor standard price."
-
-Poorly-Explained Prompt
-"Which vendors have lots of products?"
-
-Underspecified Prompt
-"List vendors and products."

--- a/datasets/dataset_AdventureWorks2022/join/prompt11.json
+++ b/datasets/dataset_AdventureWorks2022/join/prompt11.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List all products with their category and subcategory, and compute total quantity sold (zero if never sold), by joining Product → ProductSubcategory → ProductCategory and left‑joining SalesOrderDetail.",
+  "poorly-explained": "Show product sales by category.",
+  "underspecified": "List products and their sales.",
+  "follow-up": "Include product category info and total sold."
+}

--- a/datasets/dataset_AdventureWorks2022/join/prompt11.txt
+++ b/datasets/dataset_AdventureWorks2022/join/prompt11.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List all products with their category and subcategory, and compute total quantity sold (zero if never sold), by joining Product → ProductSubcategory → ProductCategory and left‑joining SalesOrderDetail."
-
-Poorly-Explained Prompt
-"Show product sales by category."
-
-Underspecified Prompt
-"List products and their sales."

--- a/datasets/dataset_AdventureWorks2022/set_op/prompt00.json
+++ b/datasets/dataset_AdventureWorks2022/set_op/prompt00.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Return a list of products that either have a list price greater than 1000 or are colored red. Show the product ID and name for each.",
+  "poorly-explained": "Give me products that are expensive or red.",
+  "underspecified": "List products.",
+  "follow-up": "Include items priced over 1000 or with color red."
+}

--- a/datasets/dataset_AdventureWorks2022/set_op/prompt00.txt
+++ b/datasets/dataset_AdventureWorks2022/set_op/prompt00.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Return a list of products that either have a list price greater than 1000 or are colored red. Show the product ID and name for each."
-
-Poorly-Explained Prompt
-"Give me products that are expensive or red."
-
-Underspecified Prompt
-"List products."

--- a/datasets/dataset_AdventureWorks2022/set_op/prompt01.json
+++ b/datasets/dataset_AdventureWorks2022/set_op/prompt01.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List employees who were hired before January 1, 2020, but exclude those whose job title is 'Manager'. Show their business entity ID, first name, and last name.",
+  "poorly-explained": "Get employees hired before 2020 except managers.",
+  "underspecified": "Show employees hired before 2020.",
+  "follow-up": "Exclude employees whose title is 'Manager'."
+}

--- a/datasets/dataset_AdventureWorks2022/set_op/prompt01.txt
+++ b/datasets/dataset_AdventureWorks2022/set_op/prompt01.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List employees who were hired before January 1, 2020, but exclude those whose job title is 'Manager'. Show their business entity ID, first name, and last name."
-
-Poorly-Explained Prompt
-"Get employees hired before 2020 except managers."
-
-Underspecified Prompt
-"Show employees hired before 2020."

--- a/datasets/dataset_AdventureWorks2022/set_op/prompt02.json
+++ b/datasets/dataset_AdventureWorks2022/set_op/prompt02.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List salespeople who have processed orders with a total due greater than 1000, but exclude those who processed orders before January 1, 2012. Show their business entity ID, first name, and last name.",
+  "poorly-explained": "Get salespeople with high-value orders after 2012.",
+  "underspecified": "Show salespeople with orders.",
+  "follow-up": "Keep only salespeople with orders >1000 and none before 2012."
+}

--- a/datasets/dataset_AdventureWorks2022/set_op/prompt02.txt
+++ b/datasets/dataset_AdventureWorks2022/set_op/prompt02.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List salespeople who have processed orders with a total due greater than 1000, but exclude those who processed orders before January 1, 2012. Show their business entity ID, first name, and last name."
-
-Poorly-Explained Prompt
-"Get salespeople with high-value orders after 2012."
-
-Underspecified Prompt
-"Show salespeople with orders."

--- a/datasets/dataset_AdventureWorks2022/str/prompt00.json
+++ b/datasets/dataset_AdventureWorks2022/str/prompt00.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Split each product’s Name into the first word and the remainder, for products whose Name contains at least one space, showing ProductID, ProductName, FirstWord, and RestOfName.",
+  "poorly-explained": "Break product names into words.",
+  "underspecified": "Parse product names.",
+  "follow-up": "Show the first word separately from the rest."
+}

--- a/datasets/dataset_AdventureWorks2022/str/prompt00.txt
+++ b/datasets/dataset_AdventureWorks2022/str/prompt00.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Split each product’s Name into the first word and the remainder, for products whose Name contains at least one space, showing ProductID, ProductName, FirstWord, and RestOfName."
-
-Poorly-Explained Prompt
-"Break product names into words."
-
-Underspecified Prompt
-"Parse product names."

--- a/datasets/dataset_AdventureWorks2022/str/prompt01.json
+++ b/datasets/dataset_AdventureWorks2022/str/prompt01.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Mark each Product whose Name contains 'bike' (case-insensitive) by returning ProductID, Name, and a flag 'ContainsBike' or 'Other', filtered to only those containing 'bike', ordered by Name.",
+  "poorly-explained": "Flag bike products.",
+  "underspecified": "Show products with bike.",
+  "follow-up": "Mark those containing 'bike' as ContainsBike."
+}

--- a/datasets/dataset_AdventureWorks2022/str/prompt01.txt
+++ b/datasets/dataset_AdventureWorks2022/str/prompt01.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Mark each Product whose Name contains 'bike' (case-insensitive) by returning ProductID, Name, and a flag 'ContainsBike' or 'Other', filtered to only those containing 'bike', ordered by Name."
-
-Poorly-Explained Prompt
-"Flag bike products."
-
-Underspecified Prompt
-"Show products with bike."

--- a/datasets/dataset_AdventureWorks2022/str/prompt02.json
+++ b/datasets/dataset_AdventureWorks2022/str/prompt02.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "For each product sold by more than one vendor, concatenate all its vendor StandardPrice values into a semicolon-separated PricesList using XML PATH and STUFF, showing ProductID, Name, and PricesList.",
+  "poorly-explained": "List product prices from vendors.",
+  "underspecified": "Show vendor prices per product.",
+  "follow-up": "Combine all vendor prices for each product."
+}

--- a/datasets/dataset_AdventureWorks2022/str/prompt02.txt
+++ b/datasets/dataset_AdventureWorks2022/str/prompt02.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"For each product sold by more than one vendor, concatenate all its vendor StandardPrice values into a semicolon-separated PricesList using XML PATH and STUFF, showing ProductID, Name, and PricesList."
-
-Poorly-Explained Prompt
-"List product prices from vendors."
-
-Underspecified Prompt
-"Show vendor prices per product."

--- a/datasets/dataset_AdventureWorks2022/str/prompt03.json
+++ b/datasets/dataset_AdventureWorks2022/str/prompt03.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Classify each product by name: label it 'Mountain' if it contains 'mountain', 'Bike' if it contains 'bike', otherwise 'Other'; also find the position of the first space, returning ProductID, Name, ProductType, FirstSpacePos, sorted by type and name.",
+  "poorly-explained": "Tag products containing mountain or bike and note where spaces are.",
+  "underspecified": "Show product type and space position.",
+  "follow-up": "Label as 'Mountain', 'Bike' or 'Other' and give first space position."
+}

--- a/datasets/dataset_AdventureWorks2022/str/prompt03.txt
+++ b/datasets/dataset_AdventureWorks2022/str/prompt03.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Classify each product by name: label it 'Mountain' if it contains 'mountain', 'Bike' if it contains 'bike', otherwise 'Other'; also find the position of the first space, returning ProductID, Name, ProductType, FirstSpacePos, sorted by type and name."
-
-Poorly-Explained Prompt
-"Tag products containing mountain or bike and note where spaces are."
-
-Underspecified Prompt
-"Show product type and space position."

--- a/datasets/dataset_AdventureWorks2022/str/prompt04.json
+++ b/datasets/dataset_AdventureWorks2022/str/prompt04.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Split each valid email address into lowercase username and uppercase domain parts, also compute total length, and return BusinessEntityID, Username, Domain, EmailLength ordered by length descending.",
+  "poorly-explained": "Break emails into username/domain and length.",
+  "underspecified": "Show split email info.",
+  "follow-up": "Return lowercase usernames, uppercase domains and email length."
+}

--- a/datasets/dataset_AdventureWorks2022/str/prompt04.txt
+++ b/datasets/dataset_AdventureWorks2022/str/prompt04.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Split each valid email address into lowercase username and uppercase domain parts, also compute total length, and return BusinessEntityID, Username, Domain, EmailLength ordered by length descending."
-
-Poorly-Explained Prompt
-"Break emails into username/domain and length."
-
-Underspecified Prompt
-"Show split email info."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt00.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt00.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Return every product whose list price is higher than the average for other products in the same subcategory. Show the product ID, name and list price.",
+  "poorly-explained": "Get the pricey products in each product group.",
+  "underspecified": "Show product names and prices.",
+  "follow-up": "Return ones priced above their subcategory average."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt00.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt00.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Return every product whose list price is higher than the average for other products in the same subcategory. Show the product ID, name and list price."
-
-Poorly-Explained Prompt
-"Get the pricey products in each product group."
-
-Underspecified Prompt
-"Show product names and prices."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt01.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt01.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List employees whose current hourly rate is above the overall company average. Include their ID, first name, last name and rate.",
+  "poorly-explained": "Who gets paid more than most?",
+  "underspecified": "Give me some employee salaries.",
+  "follow-up": "Include employees with rates above company average."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt01.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt01.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List employees whose current hourly rate is above the overall company average. Include their ID, first name, last name and rate."
-
-Poorly-Explained Prompt
-"Who gets paid more than most?"
-
-Underspecified Prompt
-"Give me some employee salaries."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt02.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt02.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find customers who have placed more orders than the average customer and show their ID plus the number of orders.",
+  "poorly-explained": "Show me customers with lots of orders.",
+  "underspecified": "List customers.",
+  "follow-up": "Only show those ordering more than the average customer."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt02.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt02.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find customers who have placed more orders than the average customer and show their ID plus the number of orders."
-
-Poorly-Explained Prompt
-"Show me customers with lots of orders."
-
-Underspecified Prompt
-"List customers."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt03.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt03.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Show sales people whose total sales exceed the overall average among all sales people. Include their ID, name and total sales amount.",
+  "poorly-explained": "Top sellers amounts.",
+  "underspecified": "Show sales data.",
+  "follow-up": "List salespeople whose totals exceed the overall average."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt03.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt03.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Show sales people whose total sales exceed the overall average among all sales people. Include their ID, name and total sales amount."
-
-Poorly-Explained Prompt
-"Top sellers amounts."
-
-Underspecified Prompt
-"Show sales data."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt04.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt04.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List vendors whose average purchase-order total is higher than the overall average purchase-order total. Show vendor ID, name and their average PO amount.",
+  "poorly-explained": "Vendors with big POs.",
+  "underspecified": "List vendors.",
+  "follow-up": "Keep vendors with average PO totals above the overall average."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt04.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt04.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List vendors whose average purchase-order total is higher than the overall average purchase-order total. Show vendor ID, name and their average PO amount."
-
-Poorly-Explained Prompt
-"Vendors with big POs."
-
-Underspecified Prompt
-"List vendors."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt05.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt05.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Return product categories that contain more products than the average category. Include the category ID, name and product count.",
+  "poorly-explained": "Categories with lots of stuff.",
+  "underspecified": "Show categories.",
+  "follow-up": "Return categories with product counts over the average."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt05.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt05.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Return product categories that contain more products than the average category. Include the category ID, name and product count."
-
-Poorly-Explained Prompt
-"Categories with lots of stuff."
-
-Underspecified Prompt
-"Show categories."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt06.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt06.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List state-province codes that have more addresses on record than the average state. Show the code and the number of addresses.",
+  "poorly-explained": "States with many addresses.",
+  "underspecified": "Give me addresses.",
+  "follow-up": "Show states whose address count exceeds the average."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt06.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt06.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List state-province codes that have more addresses on record than the average state. Show the code and the number of addresses."
-
-Poorly-Explained Prompt
-"States with many addresses."
-
-Underspecified Prompt
-"Give me addresses."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt07.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt07.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find inventory records where the quantity for a product at a specific location is below that product’s average quantity across all locations. Show product ID, name and the low quantity.",
+  "poorly-explained": "Low stock items.",
+  "underspecified": "Show inventory.",
+  "follow-up": "Include records where quantity is below that product's average."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt07.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt07.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find inventory records where the quantity for a product at a specific location is below that product’s average quantity across all locations. Show product ID, name and the low quantity."
-
-Poorly-Explained Prompt
-"Low stock items."
-
-Underspecified Prompt
-"Show inventory."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt08.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt08.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Display sales-order lines where the ordered quantity is higher than the average quantity ordered for the same product. Return order ID, product ID and quantity.",
+  "poorly-explained": "Big order details.",
+  "underspecified": "List sales order details.",
+  "follow-up": "Filter details with quantity above the product average."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt08.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt08.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Display sales-order lines where the ordered quantity is higher than the average quantity ordered for the same product. Return order ID, product ID and quantity."
-
-Poorly-Explained Prompt
-"Big order details."
-
-Underspecified Prompt
-"List sales order details."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt09.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt09.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Return the name and list price of products that are more expensive than the average price in their subcategory, along with the average and maximum prices in that subcategory.",
+  "poorly-explained": "Get products that are more expensive than others in their category with some price stats.",
+  "underspecified": "Show products and prices.",
+  "follow-up": "Add average and max price per subcategory for comparison."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt09.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt09.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Return the name and list price of products that are more expensive than the average price in their subcategory, along with the average and maximum prices in that subcategory."
-
-Poorly-Explained Prompt
-"Get products that are more expensive than others in their category with some price stats."
-
-Underspecified Prompt
-"Show products and prices."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt10.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt10.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Retrieve employees whose pay history contains rates higher than 50, showing their ID, name, average rate, and maximum rate from their pay history.",
+  "poorly-explained": "Get employees with high pay rates and some salary stats.",
+  "underspecified": "List employees.",
+  "follow-up": "Only employees with pay rates over 50 and show avg/max."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt10.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt10.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Retrieve employees whose pay history contains rates higher than 50, showing their ID, name, average rate, and maximum rate from their pay history."
-
-Poorly-Explained Prompt
-"Get employees with high pay rates and some salary stats."
-
-Underspecified Prompt
-"List employees."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt11.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt11.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Return the name, list price, total sales, and sales count for products priced higher than the average price in their subcategory. Sort the results by total sales.",
+  "poorly-explained": "Get products with high prices and their sales details, ordered by sales.",
+  "underspecified": "Show products and sales.",
+  "follow-up": "Select products priced above average and show total sales and count."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt11.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt11.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Return the name, list price, total sales, and sales count for products priced higher than the average price in their subcategory. Sort the results by total sales."
-
-Poorly-Explained Prompt
-"Get products with high prices and their sales details, ordered by sales."
-
-Underspecified Prompt
-"Show products and sales."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt12.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt12.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List salespersons who have made sales with total amounts over 500, showing their ID, name, total sales, and average sales amount.",
+  "poorly-explained": "Salespeople with big sales and their stats.",
+  "underspecified": "List salespeople.",
+  "follow-up": "Include salespeople with total sales over 500 and show averages."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt12.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt12.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List salespersons who have made sales with total amounts over 500, showing their ID, name, total sales, and average sales amount."
-
-Poorly-Explained Prompt
-"Salespeople with big sales and their stats."
-
-Underspecified Prompt
-"List salespeople."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt13.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt13.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Show products where the quantity in inventory is above the average for that product, along with the minimum and maximum quantities across all locations for that product.",
+  "poorly-explained": "Get products with high inventory and their min/max quantities.",
+  "underspecified": "Show product inventory.",
+  "follow-up": "Return inventory above average with min and max amounts."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt13.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt13.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Show products where the quantity in inventory is above the average for that product, along with the minimum and maximum quantities across all locations for that product."
-
-Poorly-Explained Prompt
-"Get products with high inventory and their min/max quantities."
-
-Underspecified Prompt
-"Show product inventory."

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt14.json
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt14.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Show products with inventory quantities lower than average, along with the total quantity sold and the maximum quantity sold for each product.",
+  "poorly-explained": "Get products with low stock and sales details.",
+  "underspecified": "Show inventory details.",
+  "follow-up": "Show items below average stock plus total and max sold."
+}

--- a/datasets/dataset_AdventureWorks2022/subquery/prompt14.txt
+++ b/datasets/dataset_AdventureWorks2022/subquery/prompt14.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Show products with inventory quantities lower than average, along with the total quantity sold and the maximum quantity sold for each product."
-
-Poorly-Explained Prompt
-"Get products with low stock and sales details."
-
-Underspecified Prompt
-"Show inventory details."

--- a/datasets/dataset_AdventureWorks2022/window/prompt00.json
+++ b/datasets/dataset_AdventureWorks2022/window/prompt00.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List all employees with their ID, first name, last name, and hire date. Additionally, rank the employees within each job title group based on their hire date in descending order, where the most recent hires get the highest rank.",
+  "poorly-explained": "Give me employees and rank them by hire date within their job group.",
+  "underspecified": "Show employees and hire dates.",
+  "follow-up": "Rank employees within each job title by hire date."
+}

--- a/datasets/dataset_AdventureWorks2022/window/prompt00.txt
+++ b/datasets/dataset_AdventureWorks2022/window/prompt00.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List all employees with their ID, first name, last name, and hire date. Additionally, rank the employees within each job title group based on their hire date in descending order, where the most recent hires get the highest rank."
-
-Poorly-Explained Prompt
-"Give me employees and rank them by hire date within their job group."
-
-Underspecified Prompt
-"Show employees and hire dates."

--- a/datasets/dataset_AdventureWorks2022/window/prompt01.json
+++ b/datasets/dataset_AdventureWorks2022/window/prompt01.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Show the name and list price of each product, and rank them within each subcategory based on their list price in descending order. The most expensive product in each subcategory will receive rank 1.",
+  "poorly-explained": "Give me products and their ranking based on price.",
+  "underspecified": "List products with their prices.",
+  "follow-up": "Rank products by price within subcategories."
+}

--- a/datasets/dataset_AdventureWorks2022/window/prompt01.txt
+++ b/datasets/dataset_AdventureWorks2022/window/prompt01.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Show the name and list price of each product, and rank them within each subcategory based on their list price in descending order. The most expensive product in each subcategory will receive rank 1."
-
-Poorly-Explained Prompt
-"Give me products and their ranking based on price."
-
-Underspecified Prompt
-"List products with their prices."

--- a/datasets/dataset_AdventureWorks2022/window/prompt02.json
+++ b/datasets/dataset_AdventureWorks2022/window/prompt02.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find the total sales for each product and rank the products within their respective subcategories based on total sales. Show the product ID, name, total sales, and the rank based on sales.",
+  "poorly-explained": "Give me products and their sales ranks.",
+  "underspecified": "Show products and their sales.",
+  "follow-up": "Rank products by total sales within subcategories."
+}

--- a/datasets/dataset_AdventureWorks2022/window/prompt02.txt
+++ b/datasets/dataset_AdventureWorks2022/window/prompt02.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find the total sales for each product and rank the products within their respective subcategories based on total sales. Show the product ID, name, total sales, and the rank based on sales."
-
-Poorly-Explained Prompt
-"Give me products and their sales ranks."
-
-Underspecified Prompt
-"Show products and their sales."

--- a/datasets/dataset_AdventureWorks2022/window/prompt03.json
+++ b/datasets/dataset_AdventureWorks2022/window/prompt03.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List all salespeople along with their total sales, and rank them within their group based on total sales in descending order. Display the salesperson's ID, name, total sales, and their rank.",
+  "poorly-explained": "Get salespeople and their sales ranks.",
+  "underspecified": "List salespeople and their sales.",
+  "follow-up": "Rank salespeople by their total sales."
+}

--- a/datasets/dataset_AdventureWorks2022/window/prompt03.txt
+++ b/datasets/dataset_AdventureWorks2022/window/prompt03.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List all salespeople along with their total sales, and rank them within their group based on total sales in descending order. Display the salesperson's ID, name, total sales, and their rank."
-
-Poorly-Explained Prompt
-"Get salespeople and their sales ranks."
-
-Underspecified Prompt
-"List salespeople and their sales."

--- a/datasets/dataset_AdventureWorks2022/window/prompt04.json
+++ b/datasets/dataset_AdventureWorks2022/window/prompt04.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "List all employees, their sick leave hours, and rank them within their job title based on the number of sick leave hours in descending order, where the employee with the most sick leave hours gets rank 1.",
+  "poorly-explained": "Get employees and rank them by sick leave hours.",
+  "underspecified": "Show employee sick leave details.",
+  "follow-up": "Rank employees by sick leave hours within their job title."
+}

--- a/datasets/dataset_AdventureWorks2022/window/prompt04.txt
+++ b/datasets/dataset_AdventureWorks2022/window/prompt04.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"List all employees, their sick leave hours, and rank them within their job title based on the number of sick leave hours in descending order, where the employee with the most sick leave hours gets rank 1."
-
-Poorly-Explained Prompt
-"Get employees and rank them by sick leave hours."
-
-Underspecified Prompt
-"Show employee sick leave details."

--- a/datasets/dataset_AdventureWorks2022/window/prompt05.json
+++ b/datasets/dataset_AdventureWorks2022/window/prompt05.json
@@ -1,0 +1,6 @@
+{
+  "well-explained": "Find the total sales for each product, and rank them within their respective subcategory based on total sales in descending order. Show the product ID, name, total sales, and sales rank.",
+  "poorly-explained": "Get products and their rank based on sales.",
+  "underspecified": "Show products and their sales.",
+  "follow-up": "Rank each product by total sales within subcategories."
+}

--- a/datasets/dataset_AdventureWorks2022/window/prompt05.txt
+++ b/datasets/dataset_AdventureWorks2022/window/prompt05.txt
@@ -1,8 +1,0 @@
-Well-Explained Prompt
-"Find the total sales for each product, and rank them within their respective subcategory based on total sales in descending order. Show the product ID, name, total sales, and sales rank."
-
-Poorly-Explained Prompt
-"Get products and their rank based on sales."
-
-Underspecified Prompt
-"Show products and their sales."

--- a/test/test_dataset_aw.py
+++ b/test/test_dataset_aw.py
@@ -88,24 +88,11 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 def load_prompt(path: Path) -> Dict[str, str]:
-    """Return prompts from file."""
+    """Return prompts from JSON file."""
 
-    text = path.read_text().strip().splitlines()
-    sections: Dict[str, str] = {}
-    current = None
-    buffer: List[str] = []
-    for line in text:
-        line = line.strip()
-        if line.endswith("Prompt"):
-            if current:
-                sections[current] = "\n".join(buffer).strip().strip('"')
-            current = line.split()[0].lower()
-            buffer = []
-        else:
-            buffer.append(line)
-    if current:
-        sections[current] = "\n".join(buffer).strip().strip('"')
-    return sections
+    import json
+
+    return json.loads(path.read_text())
 
 def collect_tests(dataset_dir: Path) -> Dict[str, List[Tuple[Path, Path, Dict[str, str]]]]:
     """Collect pairs of query and prompt files grouped by category."""
@@ -114,7 +101,7 @@ def collect_tests(dataset_dir: Path) -> Dict[str, List[Tuple[Path, Path, Dict[st
     for category in sorted(p.name for p in dataset_dir.iterdir() if p.is_dir()):
         cat_dir = dataset_dir / category
         queries = sorted(cat_dir.glob("query*.sql"))
-        prompts = sorted(cat_dir.glob("prompt*.txt"))
+        prompts = sorted(cat_dir.glob("prompt*.json"))
         cases: List[Tuple[Path, Path, Dict[str, str]]] = []
         for q, pth in zip(queries, prompts):
             cases.append((q, pth, load_prompt(pth)))


### PR DESCRIPTION
## Summary
- convert AdventureWorks prompts from txt to json
- update dataset loader to parse json files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68735346deb483208040f14758e1fe66