### PR TITLE
Fix dataset prompt loading encoding

### DIFF
--- a/test/test_utils/dataset_utils.py
+++ b/test/test_utils/dataset_utils.py
@@ -9,7 +9,7 @@ EXPECTED_KEYS = {"well-explained", "poorly-explained", "underspecified"}
 
 def load_prompt(path: Path) -> Dict[str, str]:
     """Return prompts from JSON file ensuring required keys exist."""
-    data = json.loads(path.read_text())
+    data = json.loads(path.read_text(encoding="utf-8"))
     missing = EXPECTED_KEYS - data.keys()
     if missing:
         raise ValueError(f"{path} missing keys: {', '.join(sorted(missing))}")


### PR DESCRIPTION
## Summary
- fix encoding when reading dataset prompt files to avoid UnicodeDecodeError on Windows

## Testing
- `python test/test_dataset_aw.py --languages fa` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68776901f11c8320bce6ea15c383ba39