### PR TITLE
Fix Unicode write error on Windows

### DIFF
--- a/test/test_dataset_aw.py
+++ b/test/test_dataset_aw.py
@@ -242,8 +242,8 @@ def main() -> None:
                         if df_out is not None:
                             df_out.to_csv(out_path, index=False)
 
-                        gen_sql_path.write_text(gen_sql or "")
-                        prompt_txt_path.write_text(p_text or "")
+                        gen_sql_path.write_text(gen_sql or "", encoding="utf-8")
+                        prompt_txt_path.write_text(p_text or "", encoding="utf-8")
 
                         comparison_result = compare_dataframes_as_dataframe_safe(gt_df, df_out)
 


### PR DESCRIPTION
## Summary
- specify UTF-8 encoding when writing prompt and SQL files in `test_dataset_aw.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68776ecbf8b88320b702eb4dc0db2449