### PR TITLE
Improve test output and logging

### DIFF
--- a/test/test_dataset_aw.py
+++ b/test/test_dataset_aw.py
@@ -128,7 +128,7 @@ def run_test_case(
         if prompt is None:
             raise ValueError("Prompt is None")
         if method == "ask_agent":
-            result = vn.ask_agent(question=prompt)
+            result = vn.ask_agent(question=prompt, print_results=False)
             if isinstance(result, tuple):
                 if len(result) > 0 and isinstance(result[0], str):
                     generated_sql = result[0]
@@ -272,6 +272,11 @@ def main() -> None:
                             match,
                             row_match,
                         ] + comparison_values)
+
+                        status = "SUCCESS" if not error else f"ERROR: {error}"
+                        print(
+                            f"-> {status}, match={match}, row_match={row_match}, jaccard={jaccard:.3f}"
+                        )
 
         generate_final_report(lang_dir)
 

--- a/vanna/src/vanna/base/base.py
+++ b/vanna/src/vanna/base/base.py
@@ -1961,7 +1961,13 @@ class VannaBase(ABC):
         prompt = [{"role": "user", "content": prompt_content}]
 
         try:
-            self.agent.invoke({"messages": prompt})
+            result = self.agent.invoke({"messages": prompt})
+            if isinstance(result, dict) and "messages" in result:
+                chain_msgs = []
+                for m in result["messages"]:
+                    content = m.get("content", "") if isinstance(m, dict) else str(m)
+                    chain_msgs.append(content)
+                self.log(message="\n".join(chain_msgs), title="Agent Chain")
         except Exception as e:
             self.log(message=e, title="Exception in agent")
             if print_results:


### PR DESCRIPTION
## Summary
- suppress dataframe printing in `run_test_case`
- print status summary for every executed test case
- log agent chain-of-thought messages in `VannaBase.ask_agent`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68777157a4c48320b8553e5b8835b190