### PR TITLE
Add batch runner for dataset tests

### DIFF
--- a/test/args_example.txt
+++ b/test/args_example.txt
@@ -1,0 +1,3 @@
+# Example argument sets for run_dataset_batch.py
+--model gpt-4o-mini --method ask_agent --level 1
+--model gpt-4o --method ask --level 1 --languages en fa

--- a/test/run_dataset_batch.py
+++ b/test/run_dataset_batch.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Run test_dataset_aw.py with multiple argument sets.
+
+This helper reads a text file containing argument strings and executes
+``test_dataset_aw.py`` for each line. Lines beginning with ``#`` or blank
+lines are ignored.
+
+Example::
+
+    python run_dataset_batch.py args.txt
+
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run dataset tests sequentially")
+    parser.add_argument(
+        "args_file",
+        type=Path,
+        help="Text file with argument strings, one per line",
+    )
+    parsed = parser.parse_args()
+
+    if not parsed.args_file.is_file():
+        parser.error(f"{parsed.args_file} does not exist")
+
+    with parsed.args_file.open(encoding="utf-8") as f:
+        lines = [l.strip() for l in f if l.strip() and not l.strip().startswith("#")]
+
+    script = Path(__file__).parent / "test_dataset_aw.py"
+
+    for idx, line in enumerate(lines, start=1):
+        print(f"\n=== Running configuration {idx}: {line}")
+        cmd = [sys.executable, str(script)] + line.split()
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            print(f"Configuration {idx} exited with code {result.returncode}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add helper script `run_dataset_batch.py` to run `test_dataset_aw.py` with multiple argument sets
- provide example arguments file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68777dc038e08320a6ee10b1d104718a