### PR TITLE
Handle missing vanna metadata

### DIFF
--- a/vanna/src/vanna/flask/__init__.py
+++ b/vanna/src/vanna/flask/__init__.py
@@ -1265,7 +1265,11 @@ class VannaFlaskApp(VannaFlaskAPI):
         self.config["followup_questions"] = followup_questions
         self.config["summarization"] = summarization
         self.config["function_generation"] = function_generation and hasattr(vn, "get_function")
-        self.config["version"] = importlib.metadata.version('vanna')
+        try:
+            self.config["version"] = importlib.metadata.version("vanna")
+        except importlib.metadata.PackageNotFoundError:
+            # Fallback when running from source without an installed package
+            self.config["version"] = "0.0.0"
 
         self.index_html_path = index_html_path
         self.assets_folder = assets_folder


### PR DESCRIPTION
## Summary
- avoid crash when version metadata is unavailable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687ca263668883208faa0ea89ff5e0e3