### PR TITLE
Fix version detection when running from source

### DIFF
--- a/vanna/src/vanna/flask/__init__.py
+++ b/vanna/src/vanna/flask/__init__.py
@@ -1265,7 +1265,11 @@ class VannaFlaskApp(VannaFlaskAPI):
         self.config["followup_questions"] = followup_questions
         self.config["summarization"] = summarization
         self.config["function_generation"] = function_generation and hasattr(vn, "get_function")
-        self.config["version"] = importlib.metadata.version('vanna')
+        try:
+            self.config["version"] = importlib.metadata.version('vanna')
+        except importlib.metadata.PackageNotFoundError:
+            # Fallback when running from source without package metadata
+            self.config["version"] = "source"
 
         self.index_html_path = index_html_path
         self.assets_folder = assets_folder


### PR DESCRIPTION
## Summary
- handle `PackageNotFoundError` in `VannaFlaskApp` when running from source code

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687ca7bc8bf48320aacaefd40996487e