### PR TITLE
Add category selection to dataset tests

### DIFF
--- a/test/test_utils/dataset_utils.py
+++ b/test/test_utils/dataset_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, Iterable, List, Tuple
 import json
 
 EXPECTED_KEYS = {"well-explained", "poorly-explained", "underspecified"}
@@ -24,12 +24,19 @@ def prompt_pattern(language: str) -> str:
     return f"{language}_prompt*.json"
 
 
-def collect_tests(dataset_dir: Path, language: str = "en") -> Dict[str, List[Tuple[Path, Path, Dict[str, str]]]]:
+def collect_tests(
+    dataset_dir: Path,
+    language: str = "en",
+    categories: Iterable[str] | None = None,
+) -> Dict[str, List[Tuple[Path, Path, Dict[str, str]]]]:
     """Collect query/prompt pairs grouped by category."""
+
     tests: Dict[str, List[Tuple[Path, Path, Dict[str, str]]]] = {}
     pattern = prompt_pattern(language)
 
     for category in sorted(p.name for p in dataset_dir.iterdir() if p.is_dir()):
+        if categories is not None and category not in categories:
+            continue
         cat_dir = dataset_dir / category
         queries = sorted(cat_dir.glob("query*.sql"))
         prompts = sorted(cat_dir.glob(pattern))


### PR DESCRIPTION
## Summary
- support optional category filtering in dataset utilities
- add --categories argument to dataset test script
- default to running all categories except `misc`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688702ebe4908320a677544fe8325b69